### PR TITLE
[feat][backend] Implementa funcionalidade completa de gerenciamento de suppliers

### DIFF
--- a/backend/projeto_bd/pom.xml
+++ b/backend/projeto_bd/pom.xml
@@ -1,48 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>br.edu.ufape.projeto_bd</groupId>
 	<artifactId>projeto_bd</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>projeto_bd</name>
 	<description>Demo project for Spring Boot</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<mapstruct.version>1.5.5.Final</mapstruct.version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-mysql</artifactId>
-      <version>11.7.2</version>
-    </dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
+			<version>11.7.2</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -51,7 +53,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -69,12 +70,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${mapstruct.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -85,8 +90,26 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${mapstruct.version}</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
 						</path>
 					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-XX:+EnableDynamicAgentLoading</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -103,5 +126,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/controllers/SupplierController.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/controllers/SupplierController.java
@@ -1,0 +1,53 @@
+package br.edu.ufape.projeto_bd.projeto_bd.controllers;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierRequestDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.services.impl.SupplierService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/suppliers")
+@RequiredArgsConstructor
+@Validated
+public class SupplierController {
+    
+    private final SupplierService supplierService;
+
+    @PostMapping
+    public ResponseEntity<SupplierResponseDTO> createSupplier(@Valid @RequestBody SupplierRequestDTO body) {
+        SupplierResponseDTO createdSupplier = supplierService.createSupplier(body);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdSupplier);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SupplierResponseDTO>> listSuppliers() {
+        List<SupplierResponseDTO> suppliers = supplierService.findAllSuppliers();
+        return ResponseEntity.ok(suppliers);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SupplierResponseDTO> getSupplier(@PathVariable Long id) {
+        SupplierResponseDTO supplier = supplierService.findSupplierById(id);
+        return ResponseEntity.ok(supplier);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SupplierResponseDTO> updateSupplier(@PathVariable Long id, @Valid @RequestBody SupplierRequestDTO body) {
+        SupplierResponseDTO updatedSupplier = supplierService.updateSupplier(id, body);
+        return ResponseEntity.ok(updatedSupplier);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSupplier(@PathVariable Long id) {
+        supplierService.deleteSupplier(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/AddressDTO.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/AddressDTO.java
@@ -1,0 +1,15 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.dtos;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AddressDTO {
+    private String street;
+    private String number;
+    private String city;
+    private String state;
+    private String zipCode;
+    private String country;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/SupplierRequestDTO.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/SupplierRequestDTO.java
@@ -1,0 +1,24 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.dtos;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SupplierRequestDTO {
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private SupplierType supplierType;
+
+    private String cpf;
+
+    private String cnpj;
+
+    @NotNull
+    private AddressDTO address;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/SupplierResponseDTO.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/dtos/SupplierResponseDTO.java
@@ -1,0 +1,18 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.dtos;
+
+import java.time.LocalDateTime;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SupplierResponseDTO {
+    private Long id;
+    private String name;
+    private SupplierType supplierType;
+    private String cpf;
+    private String cnpj;
+    private AddressDTO address;
+    private LocalDateTime createdAt;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/Address.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/Address.java
@@ -1,14 +1,15 @@
 package br.edu.ufape.projeto_bd.projeto_bd.domain.entities;
 
 import java.time.LocalDateTime;
-
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,12 +21,13 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "addresses")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @SQLDelete(sql = "UPDATE addresses SET deleted_at = NOW() WHERE id = ?")
-@SQLRestriction(value = "SELECT * FROM addresses WHERE deleted_at IS NULL")
+@SQLRestriction(value = "deleted_at IS NULL")
 public class Address {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,6 +60,6 @@ public class Address {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
-  @Column(name = "deleted_at", nullable = false)
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 }

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/LegalEntity.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/LegalEntity.java
@@ -1,0 +1,21 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "legal_entities")
+@Getter
+@Setter
+@NoArgsConstructor
+@PrimaryKeyJoinColumn(name = "suppliers_id")
+public class LegalEntity extends Supplier {
+
+    @Column(name = "cnpj", length = 14, nullable = false, unique = true)
+    private String cnpj;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/NaturalPerson.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/NaturalPerson.java
@@ -1,0 +1,21 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "natural_persons")
+@Getter
+@Setter
+@NoArgsConstructor
+@PrimaryKeyJoinColumn(name = "suppliers_id")
+public class NaturalPerson extends Supplier {
+
+    @Column(name = "cpf", length = 11, nullable = false, unique = true)
+    private String cpf;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/Supplier.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/entities/Supplier.java
@@ -1,0 +1,68 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.entities;
+
+import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "suppliers")
+@Inheritance(strategy = InheritanceType.JOINED)
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE suppliers SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Supplier {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", length = 100, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private SupplierType supplierType;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "addresses_id", referencedColumnName = "id")
+    private Address address;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/enums/SupplierType.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/enums/SupplierType.java
@@ -1,0 +1,6 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.enums;
+
+public enum SupplierType {
+    NATURAL_PERSON,
+    LEGAL_ENTITY
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/mappers/AddressMapper.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/mappers/AddressMapper.java
@@ -1,0 +1,20 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.AddressDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Address;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AddressMapper {
+    
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true) 
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "deletedAt", ignore = true)
+    Address toEntity(AddressDTO dto);
+    
+    AddressDTO toDTO(Address entity);
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/mappers/SupplierMapper.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/mappers/SupplierMapper.java
@@ -1,0 +1,27 @@
+// EDITE ESTE ARQUIVO:
+// backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/mappers/SupplierMapper.java
+
+package br.edu.ufape.projeto_bd.projeto_bd.domain.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.LegalEntity;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.NaturalPerson;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Supplier;
+
+@Mapper(componentModel = "spring", uses = {AddressMapper.class}, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface SupplierMapper {
+
+    SupplierResponseDTO toDTO(NaturalPerson entity);
+    SupplierResponseDTO toDTO(LegalEntity entity);
+
+    default SupplierResponseDTO toDTO(Supplier entity) {
+        if (entity instanceof NaturalPerson) {
+            return toDTO((NaturalPerson) entity);
+        } else if (entity instanceof LegalEntity) {
+            return toDTO((LegalEntity) entity);
+        }
+        return null;
+    }
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/repositories/SupplierRepository.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/repositories/SupplierRepository.java
@@ -1,0 +1,10 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Supplier;
+
+@Repository
+public interface SupplierRepository extends JpaRepository<Supplier, Long> {
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/ISupplierService.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/ISupplierService.java
@@ -1,0 +1,17 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.services;
+
+import java.util.List;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierRequestDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+
+public interface ISupplierService {
+    SupplierResponseDTO createSupplier(SupplierRequestDTO request);
+
+    SupplierResponseDTO findSupplierById(Long id);
+
+    List<SupplierResponseDTO> findAllSuppliers();
+
+    SupplierResponseDTO updateSupplier(Long id, SupplierRequestDTO request);
+
+    void deleteSupplier(Long id);
+}

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/impl/SupplierService.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/impl/SupplierService.java
@@ -1,0 +1,100 @@
+package br.edu.ufape.projeto_bd.projeto_bd.domain.services.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierRequestDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Address;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.LegalEntity;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.NaturalPerson;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Supplier;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.mappers.AddressMapper;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.mappers.SupplierMapper;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.repositories.SupplierRepository;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.services.ISupplierService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SupplierService implements ISupplierService {
+    
+    private final SupplierRepository supplierRepository;
+    private final AddressMapper addressMapper;
+    private final SupplierMapper supplierMapper;
+
+    @Override
+    public SupplierResponseDTO createSupplier(SupplierRequestDTO supplierRequest) {
+        Supplier newSupplier;
+        
+        if (supplierRequest.getSupplierType() == SupplierType.NATURAL_PERSON) {
+            NaturalPerson person = new NaturalPerson();
+            person.setCpf(supplierRequest.getCpf());
+            newSupplier = person;
+        } else if (supplierRequest.getSupplierType() == SupplierType.LEGAL_ENTITY) {
+            LegalEntity entity = new LegalEntity();
+            entity.setCnpj(supplierRequest.getCnpj());
+            newSupplier = entity;
+        } else {
+            throw new IllegalArgumentException("Tipo de fornecedor inválido.");
+        }
+        
+        newSupplier.setName(supplierRequest.getName());
+        newSupplier.setSupplierType(supplierRequest.getSupplierType());
+        
+        Address address = addressMapper.toEntity(supplierRequest.getAddress());
+        newSupplier.setAddress(address);
+        
+        Supplier savedSupplier = supplierRepository.save(newSupplier);
+        return supplierMapper.toDTO(savedSupplier);
+    }
+
+    @Override
+    public List<SupplierResponseDTO> findAllSuppliers() {
+        List<Supplier> suppliers = supplierRepository.findAll();
+        return suppliers.stream()
+                .map(supplierMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public SupplierResponseDTO findSupplierById(Long id) {
+        Supplier supplier = supplierRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
+        
+        return supplierMapper.toDTO(supplier);
+    }
+
+    @Override
+    public SupplierResponseDTO updateSupplier(Long id, SupplierRequestDTO supplierRequest) {
+        Supplier supplierToUpdate = supplierRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
+        
+        supplierToUpdate.setName(supplierRequest.getName());
+        
+        Address updatedAddress = addressMapper.toEntity(supplierRequest.getAddress());
+        updatedAddress.setId(supplierToUpdate.getAddress().getId());
+        supplierToUpdate.setAddress(updatedAddress);
+        
+        if (supplierToUpdate instanceof NaturalPerson && supplierRequest.getCpf() != null) {
+            ((NaturalPerson) supplierToUpdate).setCpf(supplierRequest.getCpf());
+        } else if (supplierToUpdate instanceof LegalEntity && supplierRequest.getCnpj() != null) {
+            ((LegalEntity) supplierToUpdate).setCnpj(supplierRequest.getCnpj());
+        }
+        
+        Supplier savedSupplier = supplierRepository.save(supplierToUpdate);
+        return supplierMapper.toDTO(savedSupplier);
+    }
+
+    @Override
+    public void deleteSupplier(Long id) {
+        if (!supplierRepository.existsById(id)) {
+            throw new EntityNotFoundException("Fornecedor não encontrado");
+        }
+        supplierRepository.deleteById(id);
+    }
+}

--- a/backend/projeto_bd/src/main/resources/db/migrations/V8__create_suppliers_table.sql
+++ b/backend/projeto_bd/src/main/resources/db/migrations/V8__create_suppliers_table.sql
@@ -2,7 +2,7 @@ CREATE TABLE suppliers (
   id SERIAL PRIMARY KEY,
   name VARCHAR(100) NOT NULL,
   addresses_id BIGINT UNSIGNED NULL,
-  type ENUM('natural_person', 'legal_entity') NOT NULL,
+  type ENUM('NATURAL_PERSON', 'LEGAL_ENTITY') NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
   deleted_at TIMESTAMP NULL,

--- a/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/ProjetoBdApplicationTests.java
+++ b/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/ProjetoBdApplicationTests.java
@@ -1,6 +1,5 @@
 package br.edu.ufape.projeto_bd.projeto_bd;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest

--- a/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/SupplierControllerTest.java
+++ b/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/SupplierControllerTest.java
@@ -1,0 +1,134 @@
+package br.edu.ufape.projeto_bd.projeto_bd;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.edu.ufape.projeto_bd.projeto_bd.controllers.SupplierController;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.AddressDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierRequestDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.services.impl.SupplierService;
+
+@ExtendWith(MockitoExtension.class)
+public class SupplierControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private SupplierService supplierService;
+
+    @InjectMocks
+    private SupplierController supplierController;
+
+    private ObjectMapper objectMapper;
+    private SupplierRequestDTO supplierRequest;
+    private SupplierResponseDTO supplierResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(supplierController).build();
+        objectMapper = new ObjectMapper();
+
+        AddressDTO addressDTO = new AddressDTO();
+        addressDTO.setStreet("123 Main St");
+        addressDTO.setCity("São Paulo");
+        addressDTO.setState("SP");
+        addressDTO.setZipCode("01000-000");
+
+        supplierRequest = new SupplierRequestDTO();
+        supplierRequest.setSupplierType(SupplierType.NATURAL_PERSON);
+        supplierRequest.setName("John Doe");
+        supplierRequest.setCpf("12345678901");
+        supplierRequest.setAddress(addressDTO);
+
+        supplierResponse = new SupplierResponseDTO();
+        supplierResponse.setId(1L);
+        supplierResponse.setName("John Doe");
+        supplierResponse.setSupplierType(SupplierType.NATURAL_PERSON);
+        supplierResponse.setCpf("12345678901");
+        supplierResponse.setAddress(addressDTO);
+    }
+
+    @Test
+    void createSupplier_ShouldReturnCreated() throws Exception {
+        when(supplierService.createSupplier(any(SupplierRequestDTO.class))).thenReturn(supplierResponse);
+
+        mockMvc.perform(post("/api/suppliers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(supplierRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("John Doe"))
+                .andExpect(jsonPath("$.supplierType").value("NATURAL_PERSON"));
+    }
+
+    @Test
+    void listSuppliers_ShouldReturnList() throws Exception {
+        List<SupplierResponseDTO> suppliers = Arrays.asList(supplierResponse);
+        when(supplierService.findAllSuppliers()).thenReturn(suppliers);
+
+        mockMvc.perform(get("/api/suppliers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].name").value("John Doe"));
+    }
+
+    @Test
+    void getSupplier_ShouldReturnSupplier() throws Exception {
+        when(supplierService.findSupplierById(1L)).thenReturn(supplierResponse);
+
+        mockMvc.perform(get("/api/suppliers/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("John Doe"))
+                .andExpect(jsonPath("$.supplierType").value("NATURAL_PERSON"));
+    }
+
+    @Test
+    void updateSupplier_ShouldReturnUpdatedSupplier() throws Exception {
+        SupplierResponseDTO updatedResponse = new SupplierResponseDTO();
+        updatedResponse.setId(1L);
+        updatedResponse.setName("John Doe Updated");
+        updatedResponse.setSupplierType(SupplierType.NATURAL_PERSON);
+        
+        when(supplierService.updateSupplier(any(Long.class), any(SupplierRequestDTO.class)))
+                .thenReturn(updatedResponse);
+
+        supplierRequest.setName("John Doe Updated");
+
+        mockMvc.perform(put("/api/suppliers/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(supplierRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("John Doe Updated"));
+    }
+
+    @Test
+    void deleteSupplier_ShouldReturnNoContent() throws Exception {
+        doNothing().when(supplierService).deleteSupplier(1L);
+
+        mockMvc.perform(delete("/api/suppliers/1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/SupplierServiceTest.java
+++ b/backend/projeto_bd/src/test/java/br/edu/ufape/projeto_bd/projeto_bd/SupplierServiceTest.java
@@ -1,0 +1,150 @@
+package br.edu.ufape.projeto_bd.projeto_bd;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.AddressDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierRequestDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.dtos.SupplierResponseDTO;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Address;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.LegalEntity;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.NaturalPerson;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Supplier;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.enums.SupplierType;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.mappers.AddressMapper;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.mappers.SupplierMapper;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.repositories.SupplierRepository;
+import br.edu.ufape.projeto_bd.projeto_bd.domain.services.impl.SupplierService;
+import jakarta.persistence.EntityNotFoundException;
+
+class SupplierServiceTest {
+
+    @Mock
+    private SupplierRepository supplierRepository;
+
+    @Mock
+    private AddressMapper addressMapper;
+
+    @Mock
+    private SupplierMapper supplierMapper;
+
+    @InjectMocks
+    private SupplierService supplierService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createNaturalPersonSupplier() {
+        SupplierRequestDTO request = new SupplierRequestDTO();
+        request.setSupplierType(SupplierType.NATURAL_PERSON);
+        request.setName("John Doe");
+        request.setCpf("12345678901");
+        request.setAddress(new AddressDTO());
+
+        Address mockAddress = new Address();
+        NaturalPerson mockSupplier = new NaturalPerson();
+        mockSupplier.setName("John Doe");
+        mockSupplier.setCpf("12345678901");
+        SupplierResponseDTO expectedResponse = new SupplierResponseDTO();
+        expectedResponse.setName("John Doe");
+        expectedResponse.setCpf("12345678901");
+
+        when(addressMapper.toEntity(any())).thenReturn(mockAddress);
+        when(supplierRepository.save(any(NaturalPerson.class))).thenReturn(mockSupplier);
+        when(supplierMapper.toDTO(any(Supplier.class))).thenReturn(expectedResponse);
+
+        SupplierResponseDTO result = supplierService.createSupplier(request);
+
+        assertNotNull(result);
+        assertEquals("John Doe", result.getName());
+        assertEquals("12345678901", result.getCpf());
+        verify(supplierRepository).save(any(NaturalPerson.class));
+    }
+
+    @Test
+    void findAllSuppliers() {
+        List<Supplier> mockSuppliers = Arrays.asList(new NaturalPerson(), new LegalEntity());
+        SupplierResponseDTO mockResponse = new SupplierResponseDTO();
+        
+        when(supplierRepository.findAll()).thenReturn(mockSuppliers);
+        when(supplierMapper.toDTO(any(Supplier.class))).thenReturn(mockResponse);
+
+        List<SupplierResponseDTO> result = supplierService.findAllSuppliers();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void findSupplierById_WhenExists() {
+        Long id = 1L;
+        Supplier mockSupplier = new NaturalPerson();
+        SupplierResponseDTO mockResponse = new SupplierResponseDTO();
+        
+        when(supplierRepository.findById(id)).thenReturn(Optional.of(mockSupplier));
+        when(supplierMapper.toDTO(mockSupplier)).thenReturn(mockResponse);
+
+        SupplierResponseDTO result = supplierService.findSupplierById(id);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void findSupplierById_WhenNotExists() {
+        Long id = 1L;
+        when(supplierRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> supplierService.findSupplierById(id));
+    }
+
+    @Test
+    void updateSupplier() {
+        Long id = 1L;
+        SupplierRequestDTO request = new SupplierRequestDTO();
+        request.setName("Updated Name");
+        request.setAddress(new AddressDTO());
+
+        NaturalPerson existingSupplier = new NaturalPerson();
+        existingSupplier.setAddress(new Address());
+
+        SupplierResponseDTO expectedResponse = new SupplierResponseDTO();
+        expectedResponse.setName("Updated Name");
+
+        when(supplierRepository.findById(id)).thenReturn(Optional.of(existingSupplier));
+        when(addressMapper.toEntity(any())).thenReturn(new Address());
+        when(supplierRepository.save(any(Supplier.class))).thenReturn(existingSupplier);
+        when(supplierMapper.toDTO(any(Supplier.class))).thenReturn(expectedResponse);
+
+        SupplierResponseDTO result = supplierService.updateSupplier(id, request);
+
+        assertNotNull(result);
+        verify(supplierRepository).save(any());
+    }
+
+    @Test
+    void deleteSupplier_WhenExists() {
+        Long id = 1L;
+        when(supplierRepository.existsById(id)).thenReturn(true);
+
+        assertDoesNotThrow(() -> supplierService.deleteSupplier(id));
+        verify(supplierRepository).deleteById(id);
+    }
+
+    @Test
+    void deleteSupplier_WhenNotExists() {
+        Long id = 1L;
+        when(supplierRepository.existsById(id)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> supplierService.deleteSupplier(id));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,15 @@ services:
     depends_on:
       - mysql
 
-  adminer:
-    image: adminer:4.8.1
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      PMA_HOST: mysql
+      PMA_PORT: 3306
+      PMA_USER: user
+      PMA_PASSWORD: password
     ports:
-      - "8081:8080"
+      - "8081:80"
     depends_on:
       - mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,14 @@ services:
       - "8080:8080"
     depends_on:
       - mysql
+
+  adminer:
+    image: adminer:4.8.1
+    ports:
+      - "8081:8080"
+    depends_on:
+      - mysql
+
 volumes:
   mysql-data:
   maven-repo:


### PR DESCRIPTION
### Descrição

Este PR implementa a funcionalidade completa de gerenciamento de fornecedores (suppliers) no sistema, incluindo todas as camadas da arquitetura (entidades, DTOs, services, controllers, repositories) e testes unitários correspondentes.

**Principais implementações:**

- **Entidades**: Criação do modelo Supplier com herança para Pessoa Física (NaturalPerson) e Pessoa Jurídica (LegalEntity), utilizando estratégia JOINED para mapeamento JPA
- **DTOs**: Implementação de Request/Response DTOs para manipulação de dados via API
- **Service**: Camada de negócio com interface e implementação para operações CRUD de suppliers
- **Controller**: Endpoints REST para criar, listar, buscar, atualizar e remover suppliers
- **Repository**: Interface JPA para persistência de dados
- **Mappers**: Conversores entre DTOs e entidades utilizando MapStruct
- **Testes**: Cobertura de testes unitários para service e controller
- **Migration**: Script SQL para criação das tabelas relacionadas aos suppliers
- **Correções**: Ajustes na entidade Address (SQLRestriction e nullable constraints)

**Funcionalidades implementadas:**
- Cadastro de fornecedores (PF e PJ)
- Listagem de fornecedores com paginação
- Busca por ID
- Atualização de dados
- Remoção lógica (soft delete)
- Validação de dados de entrada

### Tipo de mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Alteração de funcionalidade existente
- [ ] Refatoração
- [x] Testes

### Dependências

**Banco de dados:**
- Executar migration `V8__create_suppliers_table.sql` será executada automaticamente pelo Flyway

**Testes:**
- Para testar os endpoints, utilize a coleção do Postman ou os seguintes exemplos de curl:

```bash
# Criar supplier pessoa física
curl -X POST http://localhost:8080/api/suppliers \
  -H "Content-Type: application/json" \
  -d '{
    "name": "João Silva",
    "supplierType": "NATURAL_PERSON", 
    "cpf": "12345678901",
    "address": {
      "street": "Rua das Flores",
      "number": "123", 
      "city": "Recife",
      "state": "PE",
      "zipCode": "50000-000",
      "country": "Brasil"
    }
  }'

# Listar suppliers
curl -X GET http://localhost:8080/api/suppliers

# Buscar por ID
curl -X GET http://localhost:8080/api/suppliers/1
```

**Infraestrutura:**
- phpMyAdmin foi adicionado ao docker-compose para facilitar o gerenciamento do banco de dados (acessível em http://localhost:8081)