### PR TITLE
[feat][backend]: adicionar filtro por nome na listagem de clientes

### DIFF
--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/controllers/CustomerController.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/controllers/CustomerController.java
@@ -32,8 +32,8 @@ public class CustomerController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<CustomerResponseDTO>> getAllCustomers(Pageable pageable) {
-        Page<CustomerResponseDTO> customers = customerService.findAllCustomers(pageable);
+    public ResponseEntity<Page<CustomerResponseDTO>> getAllCustomers(@RequestParam(required = false) String name, Pageable pageable) {
+        Page<CustomerResponseDTO> customers = customerService.findAllCustomers(name, pageable);
         return ResponseEntity.ok(customers);
     }
 

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/repositories/CustomerRepository.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/repositories/CustomerRepository.java
@@ -3,10 +3,13 @@ package br.edu.ufape.projeto_bd.projeto_bd.domain.repositories;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import br.edu.ufape.projeto_bd.projeto_bd.domain.entities.Customer;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long>{
-	
+
+    Page<Customer> findByNameContainingIgnoreCase(String name, Pageable pageable);
+
 }

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/ICustomerService.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/ICustomerService.java
@@ -11,7 +11,7 @@ public interface ICustomerService {
 
     public CustomerResponseDTO findCustomerById(Long id);
 
-    Page<CustomerResponseDTO> findAllCustomers(Pageable pageable);
+    Page<CustomerResponseDTO> findAllCustomers(String name, Pageable pageable);
 
     public CustomerResponseDTO updateCustomer(Long id, CustomerRequestDTO request);
 

--- a/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/impl/CustomerService.java
+++ b/backend/projeto_bd/src/main/java/br/edu/ufape/projeto_bd/projeto_bd/domain/services/impl/CustomerService.java
@@ -38,8 +38,14 @@ public class CustomerService implements ICustomerService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CustomerResponseDTO> findAllCustomers(Pageable pageable) {
-        Page<Customer> customerPage = customerRepository.findAll(pageable);
+    public Page<CustomerResponseDTO> findAllCustomers(String name, Pageable pageable) {
+        Page<Customer> customerPage;
+        if (name == null || name.isBlank()) {
+            customerPage = customerRepository.findAll(pageable);
+        } else{
+            customerPage = customerRepository.findByNameContainingIgnoreCase(name, pageable);
+        }
+        
         return customerPage.map(customerMapper::toResponseDTO);
     }
 


### PR DESCRIPTION
### Descrição
Este PR adiciona a funcionalidade de filtro por nome na listagem de clientes. Agora, é possível buscar clientes pelo nome utilizando o parâmetro name na rota de listagem.

### Principais alterações:
- Adição do parâmetro opcional name no endpoint de listagem de clientes (GET /customers).
- Implementação do método findByNameContainingIgnoreCase no CustomerRepository.
- Ajuste nas interfaces e implementação do serviço de clientes para suportar o novo filtro.
### Como testar
Realizar requisições para /customers com e sem o parâmetro name e verificar se o filtro está funcionando corretamente

`GET: localhost:8080/api/customers?name=fulano`